### PR TITLE
Make the composer.lock check a bit stricter

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -39,7 +39,7 @@ class Command
         $now = new DateTime('now');
         $branch = 'composer-update-' . $now->format('YmdHis');
 
-        if (strpos(system('git status -sb'), 'composer.lock') === false) {
+        if (strpos(system('git status -s composer.lock'), 'composer.lock') === false) {
             fwrite(STDOUT, 'No changes.' . PHP_EOL);
             exit(0);
         }


### PR DESCRIPTION
Some projects also change several other files during Composer update, such as bootstrap files. When that happens, the `git status` command reports more than just one changed file. For example:

```
 M composer.lock
 M web/autoload.php
 M web/index.php
 M web/robots.txt
```

In this case, the `strpos()` function will only look at the last line (mentioning robots.txt) and conclude "No changes.".

By having the command just look at the lockfile, all other ones are excluded from the output, and the command will not fail in these cases.